### PR TITLE
Modified add_library_path utility function to prepend rather than append

### DIFF
--- a/resources/utils.py
+++ b/resources/utils.py
@@ -158,7 +158,7 @@ def add_library_paths(paths):
 
 def add_library_path(path):
     full_path = os.path.join(ADDON_PATH, path)
-    sys.path.append(full_path)
+    sys.path.insert(1, full_path)
 
 def try_encode(text, encoding="utf-8"):
     try:


### PR DESCRIPTION
So that local libraries are preferred over system-wide ones. 

On my system (Ubuntu 16.04) there is a spotify module installed under /usr/lib/python2.7/dist-packages/ which will otherwise take precedence over the spotify module under plugin.audio.spotify/resources/libs

Have seen users on http://forum.kodi.tv/showthread.php?tid=265356 reporting the same issue. Actually I suspect this will fix https://github.com/marcelveldt/plugin.audio.spotify/issues/10 as I was seeing this problem too.