### PR TITLE
Basic "Spotify Radio" functionality

### DIFF
--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -111,3 +111,7 @@ msgstr "Artiest niet volgen"
 msgctxt "#11027"
 msgid "Refresh listing"
 msgstr "Lijst vernieuwen"
+
+msgctxt "#11035"
+msgid "Play song radio"
+msgstr "Spelen radio"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -151,3 +151,7 @@ msgstr ""
 msgctxt "#11034"
 msgid "Default view for song list"
 msgstr ""
+
+msgctxt "#11035"
+msgid "Play song radio"
+msgstr ""

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -151,3 +151,7 @@ msgstr "Liste d'albums comme vue par défaut"
 msgctxt "#11034"
 msgid "Default view for song list"
 msgstr "Liste de chansons comme vue par défaut"
+
+msgctxt "#11035"
+msgid "Play song radio"
+msgstr "Jouer la radio"

--- a/resources/libs/spotipy/client.py
+++ b/resources/libs/spotipy/client.py
@@ -722,6 +722,64 @@ class Spotify(object):
         return self._get('browse/categories/' + category_id + '/playlists', country=country, 
             limit=limit, offset=offset)
 
+
+    def recommendations(self, seed_artists=None, seed_genres=None,
+                        seed_tracks=None, limit=20, country=None, **kwargs):
+        ''' Get a list of recommended tracks for one to five seeds.
+
+            Parameters:
+                - seed_artists - a list of artist IDs, URIs or URLs
+
+                - seed_tracks - a list of artist IDs, URIs or URLs
+
+                - seed_genres - a list of genre names. Available genres for
+                  recommendations can be found by calling recommendation_genre_seeds
+
+                - country - An ISO 3166-1 alpha-2 country code. If provided, all
+                  results will be playable in this country.
+
+                - limit - The maximum number of items to return. Default: 20.
+                  Minimum: 1. Maximum: 100
+
+                - min/max/target_<attribute> - For the tuneable track attributes listed
+                  in the documentation, these values provide filters and targeting on
+                  results.
+        '''
+        params = dict(limit=limit)
+        if seed_artists:
+            params['seed_artists'] = ','.join(
+                [self._get_id('artist', a) for a in seed_artists])
+        if seed_genres:
+            params['seed_genres'] = ','.join(seed_genres)
+        if seed_tracks:
+            params['seed_tracks'] = ','.join(
+                [self._get_id('track', t) for t in seed_tracks])
+        if country:
+            params['market'] = country
+
+        for attribute in ["acousticness", "danceability", "duration_ms",
+                          "energy", "instrumentalness", "key", "liveness",
+                          "loudness", "mode", "popularity", "speechiness",
+                          "tempo", "time_signature", "valence"]:
+            for prefix in ["min_", "max_", "target_"]:
+                param = prefix + attribute
+                if param in kwargs:
+                    params[param] = kwargs[param]
+        return self._get('recommendations', **params)
+
+    def recommendation_genre_seeds(self):
+        ''' Get a list of genres available for the recommendations function.
+        '''
+        return self._get('recommendations/available-genre-seeds')
+
+    def audio_analysis(self, track_id):
+        ''' Get audio analysis for a track based upon its Spotify ID
+            Parameters:
+                - track_id - a track URI, URL or ID
+        '''
+        trid = self._get_id('track', track_id)
+        return self._get('audio-analysis/' + trid)
+
     def audio_features(self, tracks=[]):
         ''' Get audio features for multiple tracks based upon their Spotify IDs
             Parameters:

--- a/resources/libs/spotipy/util.py
+++ b/resources/libs/spotipy/util.py
@@ -11,16 +11,24 @@ from . import oauth2
 import spotipy
 port = 52308
 
+PLUGIN_SPOTIFY_SCOPE="playlist-read-private playlist-read-collaborative playlist-modify-public playlist-modify-private user-follow-modify user-follow-read user-library-read user-library-modify user-read-private user-read-email user-read-birthdate user-top-read"
+PLUGIN_CLIENT_ID='4940f5cc79b149af9f71d5ef9319eff0'
+PLUGIN_CLIENT_SECRET='779F4D60BD3B42E29984ADF423F19688'
+PLUGIN_REDIRECT_URI='http://localhost:%s/callback' % port
+
+def get_token_cache_path_for_user(username):
+    return xbmc.translatePath(u"special://profile/addon_data/%s/%s.cache" % (ADDON_ID, normalize_string(username))).decode("utf-8")
+
 def prompt_for_user_token(username, scope=None, client_id = None,
         client_secret = None, redirect_uri = None):
 
-    scope = "playlist-read-private playlist-read-collaborative playlist-modify-public playlist-modify-private user-follow-modify user-follow-read user-library-read user-library-modify user-read-private user-read-email user-read-birthdate user-top-read"
-    client_id = '4940f5cc79b149af9f71d5ef9319eff0'
-    client_secret = '779f4d60bd3b42e29984adf423f19688'
-    redirect_uri = 'http://localhost:%s/callback' %port
+    scope = PLUGIN_SPOTIFY_SCOPE
+    client_id = PLUGIN_CLIENT_ID
+    client_secret = PLUGIN_CLIENT_SECRET
+    redirect_uri = PLUGIN_REDIRECT_URI
     
     #request the token
-    cachepath=xbmc.translatePath(u"special://profile/addon_data/%s/%s.cache" % (ADDON_ID,normalize_string(username))).decode("utf-8")
+    cachepath=get_token_cache_path_for_user(username)
     sp_oauth = oauth2.SpotifyOAuth(client_id, client_secret, redirect_uri, 
         scope=scope, cache_path=cachepath )
 

--- a/resources/plugincontent.py
+++ b/resources/plugincontent.py
@@ -1202,7 +1202,7 @@ class Main():
             WINDOW.setProperty("Spotify.PreCachedItems","done")
 
 class SpotifyRadioTrackBuffer(object):
-    FETCH_SIZE = 20
+    FETCH_SIZE = 100
     MIN_BUFFER_SIZE = FETCH_SIZE / 2
     CHECK_BUFFER_PERIOD = 0.5
 

--- a/resources/plugincontent.py
+++ b/resources/plugincontent.py
@@ -141,8 +141,8 @@ class Main():
         seed_track = self.sp.track(self.trackid)
         player.set_seed_tracks([seed_track])
         player.play()
-        while(not xbmc.abortRequested):
-            xbmc.sleep(100)
+        monitor = xbmc.Monitor()
+        monitor.waitForAbort()
 
     def browse_main(self):
         #main listing

--- a/resources/plugincontent.py
+++ b/resources/plugincontent.py
@@ -1255,7 +1255,7 @@ class SpotifyRadioTrackBuffer(object):
    
     def _fetch(self):
         xbmc.log("Spotify radio track buffer invoking recommendations() via spotipy")
-        tracks = self._client.recommendations(seed_tracks=[t["id"] for t in self._buffer], limit=self.FETCH_SIZE)["tracks"]
+        tracks = self._client.recommendations(seed_tracks=[t["id"] for t in self._buffer[0:5]], limit=self.FETCH_SIZE)["tracks"]
         xbmc.log("Spotify radio track buffer got %d results back" % len(tracks))
         return tracks
 


### PR DESCRIPTION
This adds a context menu item "Play song radio" when a track is selected. 

The radio mimics the functionality of the same name in the desktop apps i.e. keep playing music forever based on some seed track.

When play_track_radio is activated we instantiate a SpotifyRadioPlayer, passing the plugin object and the selected track id as the "seed". The player then plays until the request is aborted (stop).

Internally, the SpotifyRadioPlayer creates a SpotifyRadioTrackBuffer instance which is responsible for providing a constant feed of tracks available for play. Each time the player starts playing a new track (either due to skip or track finished) the player asks the buffer for the "next" track and adds that to the playlist.

When started, the SpotifyRadioTrackBuffer creates a worker thread which periodically invokes the recommendations() operation on the Spotify API. It does this only when necessary to fill up an internal buffer of recommendations (so that there is always something available when next is called).

To achieve this, I've done the following:
- Added (backported) three methods to spotipy (I haven't taken a full update to avoid the risk of breaking changes)
- Extracted a helper method parse_spotify_track() from play_track().

All the other changes are additive so have a low risk of breaking existing functionality.

