### PR TITLE
Change rating format to support float values

### DIFF
--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -299,7 +299,7 @@ def get_track_rating(popularity):
     if not popularity:
         return 0
     else:
-        return int(math.ceil(popularity * 6 / 100.0)) - 1
+        return popularity / 10.0
 
 
 def parse_spotify_track(track, is_album_track=True, silenced=False, is_connect=False):


### PR DESCRIPTION
As of version 17, [Kodi's Python API documentation](https://codedocs.xyz/xbmc/xbmc/group__python__xbmcgui__listitem.html#ga0b71166869bda87ad744942888fb5f14) states that the music rating
property provided to `xbmcgui.listItem.setInfo()` is now a float. This change updates
`get_track_rating()` to return a float between 0.0 and 10.0, by simply dividing the
popularity parameter, a percentage, by 10.