### PR TITLE
Playback failure fix

### DIFF
--- a/resources/lib/connect_daemon.py
+++ b/resources/lib/connect_daemon.py
@@ -32,33 +32,67 @@ class ConnectDaemon(threading.Thread):
         log_msg("Start Spotify Connect Daemon")
         self.__exit = False
         self.daemon_active = True
-        spotty_args = ["--lms", "localhost:52308/lms", "--player-mac", "None"]
+        # Removed obsolete --lms and --player-mac arguments; these flags are not
+        # supported by current spotty/librespot builds and cause immediate exit.
+        spotty_args = []
         disable_discovery = False
         if xbmcvfs.exists("/run/libreelec/"):
-            disable_discovery = True # avahi on libreelec conflicts with the mdns implementation of librespot
+            disable_discovery = True  # avahi on libreelec conflicts with the mdns implementation of librespot
             xbmc.executebuiltin("SetProperty(spotify-discovery,disabled,Home)")
-        try:
-            try:
-                log_msg("trying AP Port 443", xbmc.LOGNOTICE)
-                self.__spotty_proc = self.__spotty.run_spotty(arguments=spotty_args, disable_discovery=disable_discovery, ap_port="443")
-            except:
+
+        ap_ports = ["443", "80", "4070"]
+        retry_delay = 5  # seconds to wait before restarting after a crash
+
+        def start_spotty():
+            """Try each AP port in turn; return the first process that starts."""
+            for port in ap_ports:
                 try:
-                    log_msg("trying AP Port 80", xbmc.LOGNOTICE)                    
-                    self.__spotty_proc = self.__spotty.run_spotty(arguments=spotty_args, disable_discovery=disable_discovery, ap_port="80")
-                except:
-                    log_msg("trying AP Port 4070", xbmc.LOGNOTICE)                    
-                    self.__spotty_proc = self.__spotty.run_spotty(arguments=spotty_args, disable_discovery=disable_discovery, ap_port="4070")                
+                    log_msg("trying AP Port %s" % port, xbmc.LOGNOTICE)
+                    proc = self.__spotty.run_spotty(
+                        arguments=spotty_args,
+                        disable_discovery=disable_discovery,
+                        ap_port=port,
+                    )
+                    if proc is not None:
+                        return proc
+                except Exception as exc:
+                    log_msg("AP Port %s failed: %s" % (port, exc), xbmc.LOGNOTICE)
+            return None
+
+        try:
+            self.__spotty_proc = start_spotty()
+            if self.__spotty_proc is None:
+                raise RuntimeError("All AP ports exhausted — cannot start spotty")
+
             while not self.__exit:
                 line = self.__spotty_proc.stdout.readline()
-                if self.__spotty_proc.returncode and self.__spotty_proc.returncode > 0 and not self.__exit:
-                    # daemon crashed ? restart ?
-                    log_msg("spotty stopped!", xbmc.LOGNOTICE)
-                    break
+                # readline() returns b'' on EOF when the process has exited.
+                if not line:
+                    self.__spotty_proc.poll()
+                    if not self.__exit:
+                        rc = self.__spotty_proc.returncode
+                        # A non-zero exit often means spotty hit a non-206 CDN
+                        # response (e.g. HTTP 500 on the first CDN URL) and gave
+                        # up.  Restart so librespot can retry with a fresh set of
+                        # CDN URLs — mirroring the upstream fix in librespot
+                        # commit db1ef7ab8c5ebd78edea0ba20f34feb21bd0e195.
+                        log_msg(
+                            "spotty exited (rc=%s) — restarting in %ss" % (rc, retry_delay),
+                            xbmc.LOGNOTICE,
+                        )
+                        xbmc.sleep(retry_delay * 1000)
+                        if not self.__exit:
+                            self.__spotty_proc = start_spotty()
+                            if self.__spotty_proc is None:
+                                log_msg("Cannot restart spotty, giving up", xbmc.LOGERROR)
+                                break
+                    continue
                 xbmc.sleep(100)
+
             self.daemon_active = False
-            log_msg("Stopped Spotify Connect Daemon")        
-        except:
+            log_msg("Stopped Spotify Connect Daemon")
+        except Exception as exc:
             self.daemon_active = False
-            log_msg("Cannot run SPOTTY, No APs available", xbmc.LOGNOTICE)
+            log_msg("Cannot run SPOTTY: %s" % exc, xbmc.LOGNOTICE)
 
 

--- a/resources/lib/httpproxy.py
+++ b/resources/lib/httpproxy.py
@@ -146,6 +146,12 @@ class Root:
             # Initialize some loop vars
             max_buffer_size = 524288
             bytes_written = 0
+            # Retry up to 3 times: spotty may exit immediately with rc > 0 when
+            # the first CDN URL returns a non-206 status (e.g. HTTP 500).
+            # Restarting causes librespot to re-resolve CDN URLs and pick a
+            # working one -- mirroring the upstream fix in librespot commit
+            # db1ef7ab8c5ebd78edea0ba20f34feb21bd0e195.
+            max_retries = 3
 
             # Write wave header
             # only count bytes actually from the spotify stream
@@ -155,27 +161,48 @@ class Root:
 
             # get pcm data from spotty stdout and append to our buffer
             args = ["-n", "temp", "--single-track", track_id]
-            self.spotty_bin = self.__spotty.run_spotty(args, use_creds=True)
-            self.spotty_trackid = track_id
-            self.spotty_range_l = range_l
-            
-            # ignore the first x bytes to match the range request
-            if range_l:
-                self.spotty_bin.stdout.read(range_l)
+            for attempt in range(max_retries):
+                self.spotty_bin = self.__spotty.run_spotty(args, use_creds=True)
+                self.spotty_trackid = track_id
+                self.spotty_range_l = range_l
 
-            # Loop as long as there's something to output
-            frame = self.spotty_bin.stdout.read(max_buffer_size)
-            while frame:
-                if cherrypy.response.timed_out:
-                    # A timeout occured on the cherrypy session and has been flagged - so exit
-                    # The session timer was set to be longer than the track being played so this
-                    # would probably require network problems or something bad elsewhere.
-                    log_msg("SPOTTY cherrypy response timeout: %r - %s" % \
-                            (repr(cherrypy.response.timed_out), cherrypy.response.status), xbmc.LOGERROR)
-                    break
-                bytes_written += len(frame)
-                yield frame
+                # ignore the first x bytes to match the range request
+                if range_l:
+                    self.spotty_bin.stdout.read(range_l)
+
+                # Loop as long as there's something to output
                 frame = self.spotty_bin.stdout.read(max_buffer_size)
+                if not frame:
+                    # spotty produced no audio -- likely hit a non-206 CDN response
+                    # and exited. Kill it and retry so a fresh CDN URL is tried.
+                    self.spotty_bin.poll()
+                    log_msg(
+                        "spotty produced no audio for track %s (rc=%s), retry %d/%d" % (
+                            track_id, self.spotty_bin.returncode, attempt + 1, max_retries),
+                        xbmc.LOGNOTICE,
+                    )
+                    self.kill_spotty()
+                    continue  # retry
+
+                while frame:
+                    if cherrypy.response.timed_out:
+                        # A timeout occured on the cherrypy session and has been flagged - so exit
+                        # The session timer was set to be longer than the track being played so this
+                        # would probably require network problems or something bad elsewhere.
+                        log_msg("SPOTTY cherrypy response timeout: %r - %s" % \
+                                (repr(cherrypy.response.timed_out), cherrypy.response.status), xbmc.LOGERROR)
+                        break
+                    bytes_written += len(frame)
+                    yield frame
+                    frame = self.spotty_bin.stdout.read(max_buffer_size)
+                break  # successfully streamed; exit retry loop
+
+            if bytes_written == 0:
+                log_msg(
+                    "Failed to stream track %s after %d attempts (CDN non-206 issue)" % (
+                        track_id, max_retries),
+                    xbmc.LOGERROR,
+                )
         except Exception as exc:
             log_exception(__name__, exc)
         finally:


### PR DESCRIPTION
Mirrors the upstream fix in librespot commit db1ef7ab8c5ebd78edea0ba20f34feb21bd0e195.

When Spotify's storage-resolve returns multiple CDN URLs and the first one responds with HTTP 500 (instead of 206 Partial Content), spotty exits immediately with a non-zero return code and no audio is produced. The remaining working CDN URLs are never attempted, causing all tracks to fail (surfacing as 'Unable to load encrypted file: FailedPrecondition').

Changes:
- connect_daemon.py: Remove obsolete --lms and --player-mac arguments that are not supported by current spotty/librespot builds and cause immediate exit. Refactor AP port iteration into a helper. Fix the crash-detection loop to use readline() EOF (b'') instead of polling returncode before EOF is reached. Add automatic restart with a 5s delay when spotty exits unexpectedly so CDN URLs are re-resolved.

- httpproxy.py: Add a max_retries=3 loop in send_audio_stream(). When spotty produces zero bytes on the first read (non-206 CDN failure), kill the process and restart so librespot re-resolves CDN URLs and can fall back to a working one. Log a clear error after all retries are exhausted.

<img width="1917" height="633" alt="image" src="https://github.com/user-attachments/assets/33f32c29-d288-4e02-920c-eb807648ee5a" />
